### PR TITLE
fix: set vite server port to 5000

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,5 +26,8 @@ export default defineConfig({
       'react/jsx-runtime': 'preact/jsx-runtime'
     }
   },
+  server: {
+    port: 5000,
+  },
   plugins: [preact()]
 });


### PR DESCRIPTION
Fix port mismatch between expected webapp URL and actual URL.

By default, Craig expects the webapp URL to be served on [port 5000](https://github.com/CraigChat/craig/blob/e4e86ed0c42be95fd2ca48a8dd1ef030fbe7e371/apps/bot/config/_default.js#L94). However, the webapp's Vite server serves on port 3001 instead (the [default server port in Vite v2 is 3000](https://v2.vitejs.dev/config/#server-port), which is taken by [Craig's dashboard](https://github.com/CraigChat/craig/blob/e4e86ed0c42be95fd2ca48a8dd1ef030fbe7e371/install.config.example#L25), so Vite uses the next available port). Setting the Vite server port to 5000 resolves this mismatch and fixes invalid webapp URLs in Craig's recording DMs.