### PR TITLE
fix: bump recording ID field maxlength to 12

### DIFF
--- a/src/components/login.tsx
+++ b/src/components/login.tsx
@@ -111,7 +111,7 @@ export function LoginPanel({
     <Panel>
       <h1 class="text-3xl font-display text-center">{t('craigWebapp')}</h1>
       <div class="flex flex-col gap-4 w-full">
-        <Input label={t('login.recId')} error={!!error} disabled={isLoading} maxLength={10} value={recordingId} setValue={setRecordingId} />
+        <Input label={t('login.recId')} error={!!error} disabled={isLoading} maxLength={12} value={recordingId} setValue={setRecordingId} />
         <Input label={t('login.webKey')} error={!!error} disabled={isLoading} maxLength={6} value={ennuiKey} setValue={setEnnuiKey} password />
         <Dropdown disabled={isLoading} items={servers} label={t('login.server')} className="w-full" full selected={server} onSelect={setServer} />
       </div>


### PR DESCRIPTION
Bump maxlength attribute value (10 -> 12) of recording ID field in login form to match bump in https://github.com/CraigChat/craig/commit/4bc72688c30a0dfbbfef62d992cab3ba1a027030